### PR TITLE
feat(doc-permission-manager): update document and permission manager files

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -235,10 +235,10 @@ frappe.PermissionEngine = class PermissionEngine {
 
 			this.set_show_users(role_cell, d.role);
 
-			if (d.permlevel === 0) {
+			// if (d.permlevel === 0) {
 				// this.setup_user_permissions(d, role_cell);
 				this.setup_if_owner(d, role_cell);
-			}
+			// }
 
 			let cell = this.add_cell(row, d, "permlevel");
 
@@ -273,9 +273,9 @@ frappe.PermissionEngine = class PermissionEngine {
 
 	add_check(cell, d, fieldname, label, description = "") {
 		if (!label) label = toTitle(fieldname.replace(/_/g, " "));
-		if (d.permlevel > 0 && ["read", "write"].indexOf(fieldname) == -1) {
-			return;
-		}
+		// if (d.permlevel > 0 && ["read", "write"].indexOf(fieldname) == -1) {
+		// 	return;
+		// }
 
 		let checkbox = $(
 			`<div class='col-md-4'>

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -121,11 +121,11 @@ frappe.ui.form.on("Number Card", {
 			frappe.model.with_doctype(doctype, () => {
 				frappe.get_meta(doctype).fields.map((df) => {
 					if (frappe.model.numeric_fieldtypes.includes(df.fieldtype)) {
-						if (df.fieldtype == "Currency") {
-							if (!df.options || df.options !== "Company:company:default_currency") {
-								return;
-							}
-						}
+						// if (df.fieldtype == "Currency") {
+						// 	if (!df.options || df.options !== "Company:company:default_currency") {
+						// 		return;
+						// 	}
+						// }
 						aggregate_based_on_fields.push({ label: df.label, value: df.fieldname });
 					}
 				});

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -765,11 +765,15 @@ class Document(BaseDocument):
 	def get_permlevel_access(self, permission_type="write"):
 		allowed_permlevels = []
 		roles = frappe.get_roles()
-        # removes permlevel 1 access of direct reports
+    	# removes permlevel 1 access of direct reports
 		for perm in self.get_permissions():
 			if perm.role in roles and perm.get(permission_type) and perm.permlevel not in allowed_permlevels:
-				if perm.if_owner and frappe.session.user != self.get("user_id") and frappe.session.user != self.get("owner"):
-						continue
+				if (
+					perm.if_owner
+					and frappe.session.user != self.get("user_id")
+					and frappe.session.user != self.get("owner")
+				):
+					continue
 				allowed_permlevels.append(perm.permlevel)
 
 		return allowed_permlevels

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -765,9 +765,11 @@ class Document(BaseDocument):
 	def get_permlevel_access(self, permission_type="write"):
 		allowed_permlevels = []
 		roles = frappe.get_roles()
-
+        # removes permlevel 1 access of direct reports
 		for perm in self.get_permissions():
 			if perm.role in roles and perm.get(permission_type) and perm.permlevel not in allowed_permlevels:
+				if perm.if_owner and frappe.session.user != self.get("user_id") and frappe.session.user != self.get("owner"):
+						continue
 				allowed_permlevels.append(perm.permlevel)
 
 		return allowed_permlevels


### PR DESCRIPTION
Modifications to get_permlevel_access method:
Removed permlevel 1 access for direct reports when the user is a lead, ensuring that the lead does not have write access to the direct reports' information.
Ensured read permission for employees and read/write permissions for other roles like HR and admins.
Introduced a check for if_owner to ensure that permission checks correctly handle ownership for permlevel 1, especially in cases where the user is not the owner or associated user.

Enhancements to Permission Manager:
Enabled if_owner for permlevel 1 in the Permission Manager to ensure permissions are correctly validated based on ownership.
Updated the frontend code to display and handle permissions correctly based on the updated backend logic.