### PR TITLE
chore: assign trainings to employee groups

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -38,66 +38,40 @@ def get(args=None):
 		limit=5,
 	)
 
-
-@frappe.whitelist()
-def add(args=None, *, ignore_permissions=False):
-	"""add in someone's to do list
-	args = {
-	        "assign_to": [],
-	        "doctype": ,
-	        "name": ,
-	        "description": ,
-	        "assignment_rule":
-	}
-
-	"""
-	if not args:
-		args = frappe.local.form_dict
-
-	users_with_duplicate_todo = []
-	shared_with_users = []
-
-	description = escape_html(
-		args.get("description", _("Assignment for {0} {1}").format(args["doctype"], args["name"]))
-	)
-
-	for assign_to in frappe.parse_json(args.get("assign_to")):
+def create_assignment(assign_to, args, description, ignore_permissions, users_with_duplicate_todo, shared_with_users):
 		filters = {
-			"reference_type": args["doctype"],
-			"reference_name": args["name"],
-			"status": "Open",
-			"allocated_to": assign_to,
-		}
+					"reference_type": args["doctype"],
+					"reference_name": args["name"],
+					"status": "Open",
+					"allocated_to": assign_to,
+				}
 		if not ignore_permissions:
 			frappe.get_doc(args["doctype"], args["name"]).check_permission()
 
 		if frappe.get_all("ToDo", filters=filters):
 			users_with_duplicate_todo.append(assign_to)
+			return
 		else:
 			from frappe.utils import nowdate
 
-			d = frappe.get_doc(
-				{
-					"doctype": "ToDo",
-					"allocated_to": assign_to,
-					"reference_type": args["doctype"],
-					"reference_name": args["name"],
-					"description": description,
-					"priority": args.get("priority", "Medium"),
-					"status": "Open",
-					"date": args.get("date", nowdate()),
-					"assigned_by": args.get("assigned_by", frappe.session.user),
-					"assignment_rule": args.get("assignment_rule"),
-				}
-			).insert(ignore_permissions=True)
+			d = frappe.get_doc({
+				"doctype": "ToDo",
+				"allocated_to": assign_to,
+				"reference_type": args["doctype"],
+				"reference_name": args["name"],
+				"description": description,
+				"priority": args.get("priority", "Medium"),
+				"status": "Open",
+				"date": args.get("date", nowdate()),
+				"assigned_by": args.get("assigned_by", frappe.session.user),
+				"assignment_rule": args.get("assignment_rule"),
+			}).insert(ignore_permissions=True)
 
-			# set assigned_to if field exists
 			if frappe.get_meta(args["doctype"]).get_field("assigned_to"):
 				frappe.db.set_value(args["doctype"], args["name"], "assigned_to", assign_to)
 
 			doc = frappe.get_doc(args["doctype"], args["name"])
 
-			# if assignee does not have permissions, share or inform
 			if not frappe.has_permission(doc=doc, user=assign_to):
 				if frappe.get_system_settings("disable_document_sharing"):
 					msg = _("User {0} is not permitted to access this document.").format(
@@ -111,11 +85,9 @@ def add(args=None, *, ignore_permissions=False):
 					frappe.share.add(doc.doctype, doc.name, assign_to)
 					shared_with_users.append(assign_to)
 
-			# make this document followed by assigned user
 			if frappe.get_cached_value("User", assign_to, "follow_assigned_documents"):
 				follow_document(args["doctype"], args["name"], assign_to)
 
-			# notify
 			notify_assignment(
 				d.assigned_by,
 				d.allocated_to,
@@ -124,6 +96,68 @@ def add(args=None, *, ignore_permissions=False):
 				action="ASSIGN",
 				description=description,
 			)
+
+@frappe.whitelist()
+def add(args=None, *, ignore_permissions=False):
+	"""add in someone's to do list
+	args = {
+	        "assign_to": [],
+	        "doctype": ,
+	        "name": ,
+	        "description": ,
+	        "assignment_rule":
+	}
+	Add a ToDo (assignment) for one or more assignees.
+		This function now processes:
+		- Individual users from the "assign_to" field.
+		- Employee Groups from the "assign_to_employee_group" field.
+			For each employee group, it creates assignments for all employees
+			listed in the child table "Employee Group Employee".
+		
+		args should be a JSON string with keys:
+		- "assign_to": JSON list of individual assignee user IDs.
+		- "assign_to_employee_group": JSON list of Employee Group names.
+		- "doctype", "name", "description", "priority", "date", etc.
+	"""
+	if not args:
+		args = frappe.local.form_dict
+	frappe.log_error(message=str(args), title="ARGUMENTS")
+	users_with_duplicate_todo = []
+	shared_with_users = []
+
+	description = escape_html(
+		args.get("description", _("Assignment for {0} {1}").format(args["doctype"], args["name"]))
+	)
+
+	for assign_to in frappe.parse_json(args.get("assign_to") or "[]"):
+		create_assignment(assign_to, args, description,ignore_permissions,users_with_duplicate_todo, shared_with_users)
+
+	# --- New block for processing Employee Groups ---
+	# Process employee group assignments, if provided
+	for group in frappe.parse_json(args.get("assign_to_employee_group") or '[]'):
+		if frappe.db.exists("Employee Group", group):
+			# Fetch employees from the child table "Employee Group Table" with proper filters
+			employees = frappe.get_all("Employee Group Table", 
+				filters={
+					"parent": group,
+					"parentfield": "employee_list",
+					"parenttype": "Employee Group"
+				},
+				fields=["employee"]
+			)
+			for row in employees:
+				employee_id = row.employee
+				# Lookup the system user linked to the employee
+				system_user = frappe.db.get_value("Employee", employee_id, "user_id")
+				if not system_user:
+					frappe.msgprint(_("Employee {0} does not have an associated system user. Skipping assignment.").format(employee_id))
+					continue
+
+				assign_to = system_user  # Use the system user for assignment
+				create_assignment(assign_to,args,description,ignore_permissions,users_with_duplicate_todo,shared_with_users)
+			
+		else:
+			frappe.msgprint(_("Employee Group {0} does not exist.").format(group))
 
 	if shared_with_users:
 		user_list = format_message_for_assign_to(shared_with_users)

--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -101,7 +101,7 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 			primary_action: function () {
 				let args = me.dialog.get_values();
 
-				if (args && args.assign_to) {
+				if (args && (args.assign_to || args.assign_to_employee_group)) {
 					me.dialog.set_message("Assigning...");
 
 					frappe.call({
@@ -110,6 +110,7 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 							doctype: me.doctype,
 							name: me.docname,
 							assign_to: args.assign_to,
+							assign_to_employee_group: args.assign_to_employee_group,
 							bulk_assign: me.bulk_assign || false,
 							re_assign: me.re_assign || false,
 						}),
@@ -139,6 +140,21 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 
 		me.dialog.set_value("assign_to", assign_to);
 	}
+	employee_group_list() {
+		let me = this;
+		me.dialog.set_value("assign_to_me", 0);
+	
+		// Fetch Employee Groups directly
+		frappe.db.get_list("Employee Group", {
+			fields: ["employee_group_name"]  
+		}).then((response) => {
+			// Create a newline-separated string of options for the MultiSelectPills field
+			let employee_groups = response.map((group) => group.name).join("\n");
+			me.dialog.fields_dict.assign_to_employee_group.df.options = employee_groups;
+			me.dialog.refresh_field("assign_to_employee_group");
+		});
+	}	
+	
 	user_group_list() {
 		let me = this;
 		let user_group = me.dialog.get_value("assign_to_user_group");
@@ -177,17 +193,18 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 				onchange: () => me.assign_to_me(),
 			},
 			{
-				label: __("Assign To User Group"),
-				fieldtype: "Link",
-				fieldname: "assign_to_user_group",
-				options: "User Group",
-				onchange: () => me.user_group_list(),
+				label: __("Assign To Employee Group"),
+				fieldtype: "MultiSelectPills",
+				fieldname: "assign_to_employee_group",
+				// options: "Employee Group",
+				get_data: function (txt) {
+					return frappe.db.get_link_options("Employee Group", txt);
+				},
 			},
 			{
 				fieldtype: "MultiSelectPills",
 				fieldname: "assign_to",
 				label: __("Assign To"),
-				reqd: true,
 				get_data: function (txt) {
 					return frappe.db.get_link_options("User", txt, {
 						user_type: "System User",
@@ -265,6 +282,7 @@ frappe.ui.form.AssignmentDialog = class {
 							this.assigning = true;
 							this.dialog.set_df_property("user", "read_only", 1);
 							this.dialog.set_df_property("user", "description", __("Assigning..."));
+							console.log("after assigning");
 							this.add_assignment(value)
 								.then(() => {
 									this.dialog.set_value("user", null);
@@ -296,6 +314,7 @@ frappe.ui.form.AssignmentDialog = class {
 		this.frm && this.frm.assign_to.render(assignments);
 	}
 	add_assignment(assignment) {
+		console.log("add btn called");
 		return frappe
 			.xcall("frappe.desk.form.assign_to.add", {
 				doctype: this.frm.doctype,


### PR DESCRIPTION
Assignment of Training Session to one or more employee groups:
Modified frontend assign_to.js to include MultiSelect field for assign to Employee Groups
Modified backend assign_to.py to handle added employee_groups -> go through list of employees in each employee group and add them to field "assign_to"